### PR TITLE
Support non-boolean scope-attributes

### DIFF
--- a/stups-spring-oauth2-server/src/main/java/org/zalando/stups/oauth2/spring/server/TokenInfoResourceServerTokenServices.java
+++ b/stups-spring-oauth2-server/src/main/java/org/zalando/stups/oauth2/spring/server/TokenInfoResourceServerTokenServices.java
@@ -20,7 +20,6 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
-import com.sun.org.apache.xpath.internal.operations.Bool;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;

--- a/stups-spring-oauth2-server/src/main/java/org/zalando/stups/oauth2/spring/server/TokenInfoResourceServerTokenServices.java
+++ b/stups-spring-oauth2-server/src/main/java/org/zalando/stups/oauth2/spring/server/TokenInfoResourceServerTokenServices.java
@@ -20,6 +20,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
+import com.sun.org.apache.xpath.internal.operations.Bool;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -151,8 +152,7 @@ public class TokenInfoResourceServerTokenServices implements ResourceServerToken
             for (String scope : scopes) {
                 Object permission = map.get(scope);
                 if (permission != null) {
-                    Boolean b = (Boolean) permission;
-                    if (Boolean.TRUE.equals(b)) {
+                    if (Boolean.parseBoolean(permission.toString())) {
                         permissions.add(scope);
                     }
                 }

--- a/stups-spring-oauth2-server/src/test/java/some/test/TokenInfoResourceServerTokenServicesTest.java
+++ b/stups-spring-oauth2-server/src/test/java/some/test/TokenInfoResourceServerTokenServicesTest.java
@@ -15,22 +15,6 @@
  */
 package some.test;
 
-/**
- * Copyright 2015 Zalando SE
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.Test;

--- a/stups-spring-oauth2-server/src/test/java/some/test/controller/TokeninfoEndpoint.java
+++ b/stups-spring-oauth2-server/src/test/java/some/test/controller/TokeninfoEndpoint.java
@@ -15,35 +15,17 @@
  */
 package some.test.controller;
 
-/**
- * Copyright 2015 Zalando SE
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-import java.util.Map;
-
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import org.springframework.stereotype.Controller;
-
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
 
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
+import java.util.List;
+import java.util.Map;
 
 /**
  * Maybe this works.
@@ -55,6 +37,7 @@ public class TokeninfoEndpoint {
 
     private final Logger logger = LoggerFactory.getLogger(TokeninfoEndpoint.class);
 
+    @SuppressWarnings("unchecked")
     @RequestMapping(value = "/tokeninfo")
     @ResponseBody
     public Map<String, Object> fakeTheResponse(@RequestHeader("Authorization") final String authorizationHeader) {
@@ -68,6 +51,7 @@ public class TokeninfoEndpoint {
         } else if (authorizationHeader.contains("no-uid")) {
             result = buildAccessToken(accessTokenFromHeader);
             result.remove("uid");
+            ((List<String>) result.get("scope")).remove("uid");
         } else if (authorizationHeader.contains("empty-uid")) {
             result = buildAccessToken(accessTokenFromHeader);
             result.put("uid", "");
@@ -94,7 +78,7 @@ public class TokeninfoEndpoint {
         result.put("access_token", accessTokenFromHeader);
         result.put("token_type", "Bearer");
         result.put("expires_in", 5000);
-        result.put("scope", Lists.newArrayList("simpleScope", "extrascope", "testscope"));
+        result.put("scope", Lists.newArrayList("uid", "simpleScope", "extrascope", "testscope"));
         result.put("testscope", Boolean.TRUE);
         result.put("simpleScope", Boolean.FALSE);
 


### PR DESCRIPTION
For scopes with a non-boolean attribute assume that the permission is not given. For example there are token servers out there that add 'uid' as a scope and a non-boolean attribute.