### PR TITLE
Pick up scopes from 'scope' attribute

### DIFF
--- a/stups-spring-oauth2-server/src/main/java/org/zalando/stups/oauth2/spring/server/TokenInfoResourceServerTokenServices.java
+++ b/stups-spring-oauth2-server/src/main/java/org/zalando/stups/oauth2/spring/server/TokenInfoResourceServerTokenServices.java
@@ -135,7 +135,6 @@ public class TokenInfoResourceServerTokenServices implements ResourceServerToken
      */
     protected Set<String> getScopesWithPermissionTrueFromMap(final Map<String, Object> map) {
         Set<String> scopes = new HashSet<String>();
-        Set<String> permissions = new HashSet<String>();
         try {
             Object scopeValue = map.get("scope");
             if (scopeValue != null) {
@@ -147,21 +146,11 @@ public class TokenInfoResourceServerTokenServices implements ResourceServerToken
                 }
             }
 
-            // important part, check the scope has the permission, indicated by 'true' as value
-            for (String scope : scopes) {
-                Object permission = map.get(scope);
-                if (permission != null) {
-                    if (Boolean.parseBoolean(permission.toString())) {
-                        permissions.add(scope);
-                    }
-                }
-            }
-
         } catch (Exception e) {
             logger.error("Unable to get 'scope' value from map", e);
         }
 
-        return permissions;
+        return scopes;
     }
 
     protected Object getPrincipal(final Map<String, Object> map) {

--- a/stups-spring-oauth2-server/src/test/java/some/test/controller/SecuredResource.java
+++ b/stups-spring-oauth2-server/src/test/java/some/test/controller/SecuredResource.java
@@ -15,21 +15,21 @@
  */
 package some.test.controller;
 
-import java.util.Optional;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
+import org.springframework.security.oauth2.provider.OAuth2Authentication;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-
 import org.zalando.stups.oauth2.spring.client.AccessTokenUtils;
+
+import java.util.Optional;
+import java.util.Set;
 
 /**
  * The Resource we secured with OAuth2.
  *
- * @author  jbellmann
+ * @author jbellmann
  */
 @RestController
 public class SecuredResource {
@@ -41,6 +41,11 @@ public class SecuredResource {
         Optional<String> accessToken = AccessTokenUtils.getAccessTokenFromSecurityContext();
         logger.info("SECURED-RESOURCE ACCESSED WITH TOKEN : {}", accessToken.get());
         return "hello " + term;
+    }
+
+    @RequestMapping("/secured/bye")
+    public Set<String> bye(final OAuth2Authentication auth) {
+        return auth.getOAuth2Request().getScope();
     }
 
 }

--- a/stups-spring-oauth2-server/src/test/java/some/test/controller/TokeninfoEndpoint.java
+++ b/stups-spring-oauth2-server/src/test/java/some/test/controller/TokeninfoEndpoint.java
@@ -15,8 +15,8 @@
  */
 package some.test.controller;
 
-import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Controller;
@@ -24,18 +24,21 @@ import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
 
-import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Maybe this works.
  *
- * @author  jbellmann
+ * @author jbellmann
  */
 @Controller
 public class TokeninfoEndpoint {
 
     private final Logger logger = LoggerFactory.getLogger(TokeninfoEndpoint.class);
+
+    public static final Set<String> ALL_SCOPES =
+            Sets.newHashSet("uid", "simpleScope", "extrascope", "testscope");
 
     @SuppressWarnings("unchecked")
     @RequestMapping(value = "/tokeninfo")
@@ -51,7 +54,7 @@ public class TokeninfoEndpoint {
         } else if (authorizationHeader.contains("no-uid")) {
             result = buildAccessToken(accessTokenFromHeader);
             result.remove("uid");
-            ((List<String>) result.get("scope")).remove("uid");
+            ((Set<String>) result.get("scope")).remove("uid");
         } else if (authorizationHeader.contains("empty-uid")) {
             result = buildAccessToken(accessTokenFromHeader);
             result.put("uid", "");
@@ -78,10 +81,10 @@ public class TokeninfoEndpoint {
         result.put("access_token", accessTokenFromHeader);
         result.put("token_type", "Bearer");
         result.put("expires_in", 5000);
-        result.put("scope", Lists.newArrayList("uid", "simpleScope", "extrascope", "testscope"));
+        result.put("scope", ALL_SCOPES);
         result.put("testscope", Boolean.TRUE);
-        result.put("simpleScope", Boolean.FALSE);
-
+        result.put("simpleScope", "");
+        result.put("extrascope", Boolean.FALSE);
         return result;
     }
 }


### PR DESCRIPTION
When checking for allowed scopes one should not check the token's attributes but just take what the top-level 'scope' array offers.