### PR TITLE
Fix stups access token provider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 .classpath
 .project
 target
+.idea
+*.iml

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
         <spring-boot.version>1.2.5.RELEASE</spring-boot.version>
         <spring.security.oauth2>2.0.7.RELEASE</spring.security.oauth2>
         <guava.version>18.0</guava.version>
-        <assertj.version>3.0.0</assertj.version>
+        <assertj.version>3.1.0</assertj.version>
         <mockito.version>1.10.19</mockito.version>
 
         <stups-tokens.version>0.9.0</stups-tokens.version>
@@ -73,7 +73,7 @@
                 <plugin>
                     <groupId>org.jacoco</groupId>
                     <artifactId>jacoco-maven-plugin</artifactId>
-                    <version>0.7.4.201502262128</version>
+                    <version>0.7.5.201505241946</version>
                     <executions>
                         <execution>
                             <id>default-prepare-agent</id>
@@ -114,6 +114,7 @@
                         <jacocoReport>stups-spring-oauth2-client/target/site/jacoco/jacoco.xml</jacocoReport>
                         <jacocoReport>stups-spring-oauth2-server/target/site/jacoco/jacoco.xml</jacocoReport>
                         <jacocoReport>stups-http-components-oauth2/target/site/jacoco/jacoco.xml</jacocoReport>
+                        <jacocoReport>stups-jaxws-oauth2/target/site/jacoco/jacoco.xml</jacocoReport>
                     </jacocoReports>
                 </configuration>
             </plugin>

--- a/stups-jaxws-oauth2/pom.xml
+++ b/stups-jaxws-oauth2/pom.xml
@@ -57,4 +57,13 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/stups-spring-oauth2-client/src/main/java/org/zalando/stups/oauth2/spring/client/StupsTokensAccessTokenProvider.java
+++ b/stups-spring-oauth2-client/src/main/java/org/zalando/stups/oauth2/spring/client/StupsTokensAccessTokenProvider.java
@@ -1,0 +1,78 @@
+/**
+ * Copyright (C) 2015 Zalando SE (http://tech.zalando.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zalando.stups.oauth2.spring.client;
+
+import static java.lang.System.currentTimeMillis;
+import static org.springframework.security.oauth2.common.OAuth2AccessToken.ACCESS_TOKEN;
+import static org.springframework.security.oauth2.common.OAuth2AccessToken.EXPIRES_IN;
+import static org.springframework.security.oauth2.common.OAuth2AccessToken.TOKEN_TYPE;
+import static org.springframework.util.StringUtils.capitalize;
+
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.TreeMap;
+
+import org.springframework.security.oauth2.client.resource.OAuth2ProtectedResourceDetails;
+import org.springframework.security.oauth2.client.token.AccessTokenRequest;
+import org.springframework.security.oauth2.common.DefaultOAuth2AccessToken;
+import org.springframework.security.oauth2.common.OAuth2AccessToken;
+import org.springframework.security.oauth2.common.exceptions.OAuth2Exception;
+import org.springframework.util.Assert;
+import org.zalando.stups.tokens.AccessToken;
+import org.zalando.stups.tokens.AccessTokenUnavailableException;
+import org.zalando.stups.tokens.AccessTokens;
+
+/**
+ * An AccessTokenProvider that utilizes the {@link AccessTokens} object,
+ * defined in <a href="https://github.com/zalando-stups/tokens">Zalando STUPS' "tokens" library</a>,
+ * to obtain an access token.
+ */
+public class StupsTokensAccessTokenProvider extends AbstractStupsAccessTokenProvider {
+
+    private final String tokenId;
+
+    private final AccessTokens tokens;
+
+    public StupsTokensAccessTokenProvider(String tokenId, AccessTokens tokens) {
+        Assert.hasText(tokenId, "tokenId cannot be left blank");
+        Assert.notNull(tokens, "tokens must not be null");
+        this.tokenId = tokenId;
+        this.tokens = tokens;
+    }
+
+    @Override
+    public OAuth2AccessToken obtainAccessToken(final OAuth2ProtectedResourceDetails details,
+            final AccessTokenRequest parameters) {
+        final AccessToken accessToken;
+        try {
+            accessToken = tokens.getAccessToken(tokenId);
+        }
+        catch (final AccessTokenUnavailableException e) {
+            throw new OAuth2Exception("Could not obtain access token.", e);
+        }
+
+        final Map<String, String> tokenParams = new HashMap<>();
+        tokenParams.put(ACCESS_TOKEN, accessToken.getToken());
+        tokenParams.put(TOKEN_TYPE, capitalize(accessToken.getType()));
+        tokenParams.put(EXPIRES_IN, secondsTo(accessToken.getValidUntil()));
+        return DefaultOAuth2AccessToken.valueOf(tokenParams);
+    }
+
+    private String secondsTo(Date until) {
+        return String.valueOf((until.getTime() - currentTimeMillis()) / 1000);
+    }
+}

--- a/stups-spring-oauth2-client/src/test/java/org/zalando/stups/oauth2/spring/client/StupsTokensAccessTokenProviderTest.java
+++ b/stups-spring-oauth2-client/src/test/java/org/zalando/stups/oauth2/spring/client/StupsTokensAccessTokenProviderTest.java
@@ -1,0 +1,106 @@
+/**
+ * Copyright (C) 2015 Zalando SE (http://tech.zalando.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zalando.stups.oauth2.spring.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
+import static org.assertj.core.util.DateUtil.tomorrow;
+import static org.assertj.core.util.DateUtil.yesterday;
+import static org.mockito.Matchers.anyObject;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.security.oauth2.client.resource.BaseOAuth2ProtectedResourceDetails;
+import org.springframework.security.oauth2.client.token.DefaultAccessTokenRequest;
+import org.springframework.security.oauth2.common.OAuth2AccessToken;
+import org.springframework.security.oauth2.common.exceptions.OAuth2Exception;
+import org.zalando.stups.tokens.AccessToken;
+import org.zalando.stups.tokens.AccessTokenUnavailableException;
+import org.zalando.stups.tokens.AccessTokens;
+
+public class StupsTokensAccessTokenProviderTest {
+
+    private static final String TOKEN_ID = "a-token-name";
+
+    private AccessTokens mockAccessTokens;
+
+    private StupsTokensAccessTokenProvider accessTokenProvider;
+
+    @Before
+    public void setUp() throws Exception {
+        mockAccessTokens = mock(AccessTokens.class);
+
+        accessTokenProvider = new StupsTokensAccessTokenProvider(TOKEN_ID, mockAccessTokens);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        verifyNoMoreInteractions(mockAccessTokens);
+    }
+
+    @Test
+    public void testObtainAccessToken() throws Exception {
+        when(mockAccessTokens.getAccessToken(anyString())).thenReturn(
+                new AccessToken("12345", "bearer", 3600, tomorrow()));
+        final OAuth2AccessToken accessToken = accessTokenProvider.obtainAccessToken(
+                new BaseOAuth2ProtectedResourceDetails(), new DefaultAccessTokenRequest());
+
+        assertThat(accessToken).isNotNull();
+        assertThat(accessToken.getValue()).isEqualTo("12345");
+        assertThat(accessToken.getTokenType()).isEqualTo("Bearer");
+        assertThat(accessToken.isExpired()).isFalse();
+
+        verify(mockAccessTokens).getAccessToken(eq(TOKEN_ID));
+    }
+
+    @Test
+    public void testObtainExpiredAccessToken() throws Exception {
+        when(mockAccessTokens.getAccessToken(anyString())).thenReturn(
+                new AccessToken("12345", "bearer", 3600, yesterday()));
+        final OAuth2AccessToken accessToken = accessTokenProvider.obtainAccessToken(
+                new BaseOAuth2ProtectedResourceDetails(), new DefaultAccessTokenRequest());
+
+        assertThat(accessToken).isNotNull();
+        assertThat(accessToken.getValue()).isEqualTo("12345");
+        assertThat(accessToken.getTokenType()).isEqualTo("Bearer");
+        assertThat(accessToken.isExpired()).isTrue();
+
+        verify(mockAccessTokens).getAccessToken(eq(TOKEN_ID));
+    }
+
+    @Test
+    public void testObtainAccessTokenException() throws Exception {
+        final AccessTokenUnavailableException unavailableAccessToken = new AccessTokenUnavailableException();
+        when(mockAccessTokens.getAccessToken(anyObject())).thenThrow(unavailableAccessToken);
+        try {
+            accessTokenProvider.obtainAccessToken(
+                    new BaseOAuth2ProtectedResourceDetails(),
+                    new DefaultAccessTokenRequest());
+            failBecauseExceptionWasNotThrown(OAuth2Exception.class);
+        }
+        catch (OAuth2Exception e) {
+            assertThat(e).hasCause(unavailableAccessToken);
+            verify(mockAccessTokens).getAccessToken(eq(TOKEN_ID));
+        }
+    }
+}


### PR DESCRIPTION
The existing StupsAccessTokenProvider uses only the String value to create access tokens. However some libs require the expiration date to be set.

Therefore I created a new StupsTokensAccessTokenProvider, that uses the AccessTokens interface instead of TokenProvider to obtain access tokens.