### PR TITLE
Treat empty token as invalid token

### DIFF
--- a/stups-spring-oauth2-server/src/main/java/org/zalando/stups/oauth2/spring/server/TokenInfoResourceServerTokenServices.java
+++ b/stups-spring-oauth2-server/src/main/java/org/zalando/stups/oauth2/spring/server/TokenInfoResourceServerTokenServices.java
@@ -108,7 +108,9 @@ public class TokenInfoResourceServerTokenServices implements ResourceServerToken
 	public OAuth2Authentication loadAuthentication(final String accessToken)
 			throws AuthenticationException, InvalidTokenException {
 
-		Assert.hasText(accessToken, "'accessToken' should never be null or empty");
+		if (!StringUtils.hasText(accessToken)) {
+			throw new InvalidTokenException("'accessToken' should never be null or empty");
+		}
 
 		Map<String, Object> map = null;
 

--- a/stups-spring-oauth2-server/src/test/java/org/zalando/stups/oauth2/spring/server/TokenInfoResourceServerTokenServicesTest.java
+++ b/stups-spring-oauth2-server/src/test/java/org/zalando/stups/oauth2/spring/server/TokenInfoResourceServerTokenServicesTest.java
@@ -24,6 +24,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.http.RequestEntity;
+import org.springframework.security.oauth2.common.exceptions.InvalidTokenException;
 
 /**
  * @author  jbellmann
@@ -85,5 +86,11 @@ public class TokenInfoResourceServerTokenServicesTest {
     	
     	Assertions.assertThat(entity.getHeaders()).containsKey(HttpHeaders.ACCEPT);
     	Assertions.assertThat(entity.getHeaders().getAccept()).contains(MediaType.APPLICATION_JSON);
+    }
+
+    @Test(expected = InvalidTokenException.class)
+    public void emptyTokenIsInvalid() {
+        final TokenInfoResourceServerTokenServices unit = new TokenInfoResourceServerTokenServices(TOKENINFO_URL);
+        unit.loadAuthentication("");
     }
 }


### PR DESCRIPTION
OAuth2ClientAuthenticationProcessingFilter catches **InvalidTokenException** and maps it to a **BadCredentialsException** which treats the request as unauthorized.

This fixes #23 