### PR TITLE
improved insufficient realms error response

### DIFF
--- a/stups-spring-oauth2-server/src/main/java/org/zalando/stups/oauth2/spring/security/expression/ExtendedOAuth2SecurityExpressionMethods.java
+++ b/stups-spring-oauth2-server/src/main/java/org/zalando/stups/oauth2/spring/security/expression/ExtendedOAuth2SecurityExpressionMethods.java
@@ -1,13 +1,12 @@
 package org.zalando.stups.oauth2.spring.security.expression;
 
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.provider.expression.OAuth2SecurityExpressionMethods;
+
 import java.util.Arrays;
 import java.util.LinkedHashSet;
 import java.util.Set;
-
-import org.springframework.security.access.AccessDeniedException;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.oauth2.common.exceptions.InsufficientScopeException;
-import org.springframework.security.oauth2.provider.expression.OAuth2SecurityExpressionMethods;
 
 /**
  * 
@@ -25,7 +24,7 @@ public class ExtendedOAuth2SecurityExpressionMethods extends OAuth2SecurityExpre
     @Override
     public boolean throwOnError(boolean decision) {
         if (!decision && !missingRealms.isEmpty()) {
-            Throwable failure = new InsufficientScopeException("Insufficient realms for this resource", missingRealms);
+            Throwable failure = new InsufficientRealmException("Insufficient realms for this resource", missingRealms);
             throw new AccessDeniedException(failure.getMessage(), failure);
         }
         // do not forget to call super

--- a/stups-spring-oauth2-server/src/main/java/org/zalando/stups/oauth2/spring/security/expression/InsufficientRealmException.java
+++ b/stups-spring-oauth2-server/src/main/java/org/zalando/stups/oauth2/spring/security/expression/InsufficientRealmException.java
@@ -1,0 +1,29 @@
+package org.zalando.stups.oauth2.spring.security.expression;
+
+import org.springframework.security.oauth2.common.exceptions.OAuth2Exception;
+import org.springframework.security.oauth2.common.util.OAuth2Utils;
+
+import java.util.Set;
+
+public class InsufficientRealmException extends OAuth2Exception {
+
+    public InsufficientRealmException(String msg, Set<String> validRealms) {
+        this(msg);
+        addAdditionalInformation("realm", OAuth2Utils.formatParameterList(validRealms));
+    }
+
+    public InsufficientRealmException(String msg) {
+        super(msg);
+    }
+
+    @Override
+    public int getHttpErrorCode() {
+        return 403;
+    }
+
+    @Override
+    public String getOAuth2ErrorCode() {
+        // Not defined in the spec, so not really an OAuth2Exception
+        return "insufficient_realm";
+    }
+}


### PR DESCRIPTION
In case of realm validation error the following response is returned:

{
  "error": "insufficient_scope",
  "error_description": "Insufficient realms for this resource",
  "scope": "/services"
}

With the PR changes it will be:
{
  "error": "**insufficient_realm**",
  "error_description": "Insufficient realms for this resource",
  "**realm**": "/services"
}