### PR TITLE
Bump spring security to 4.2.1.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
 		<main.basedir>${basedir}/..</main.basedir>
 
 		<spring-boot.version>1.3.3.RELEASE</spring-boot.version>
-		<spring.security.oauth2>2.0.8.RELEASE</spring.security.oauth2>
+		<spring.security.oauth2>2.0.12.RELEASE</spring.security.oauth2>
 		<guava.version>19.0</guava.version>
 		<assertj.version>2.3.0</assertj.version>
 		<mockito.version>1.10.19</mockito.version>

--- a/stups-spring-oauth2-server/pom.xml
+++ b/stups-spring-oauth2-server/pom.xml
@@ -13,10 +13,41 @@
             <artifactId>stups-spring-oauth2-common</artifactId>
             <version>${project.version}</version>
         </dependency>
+        
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-core</artifactId>
+            <version>4.2.1.RELEASE</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-config</artifactId>
+            <version>4.2.1.RELEASE</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-web</artifactId>
+            <version>4.2.1.RELEASE</version>
+        </dependency>
+
         <dependency>
             <groupId>org.springframework.security.oauth</groupId>
             <artifactId>spring-security-oauth2</artifactId>
             <version>${spring.security.oauth2}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.springframework.security</groupId>
+                    <artifactId>spring-security-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.springframework.security</groupId>
+                    <artifactId>spring-security-config</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.springframework.security</groupId>
+                    <artifactId>spring-security-web</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>


### PR DESCRIPTION
Old version shipping with spring security
oauth contains cve (https://spring.io/blog/2016/12/22/cve-2016-9879-spring-security-3-2-10-4-1-4-4-2-1-released).