### PR TITLE
Add support for Hystrix and Failsafe based Circuit Breaker TokenInfoRequestExecutors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,9 @@
 		<spring-boot-zalando-stups-tokens.version>0.9.6</spring-boot-zalando-stups-tokens.version>
 		<kio-client-java-spring.version>0.9.4</kio-client-java-spring.version>
 
+		<hystrix.version>1.5.12</hystrix.version>
+		<failsafe.version>1.0.4</failsafe.version>
+
         <spring-security.version>4.2.1.RELEASE</spring-security.version>
         <spring-security-oauth2.version>2.0.12.RELEASE</spring-security-oauth2.version>
 		<java.source>1.7</java.source>
@@ -109,6 +112,18 @@
 				<artifactId>kio-client-java-spring</artifactId>
 				<version>${kio-client-java-spring.version}</version>
 			</dependency>
+
+			<dependency>
+				<groupId>com.netflix.hystrix</groupId>
+				<artifactId>hystrix-core</artifactId>
+				<version>${hystrix.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>net.jodah</groupId>
+				<artifactId>failsafe</artifactId>
+				<version>${failsafe.version}</version>
+			</dependency>
+
 		</dependencies>
 	</dependencyManagement>
 

--- a/stups-spring-oauth2-server/pom.xml
+++ b/stups-spring-oauth2-server/pom.xml
@@ -24,6 +24,18 @@
             <artifactId>slf4j-api</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>com.netflix.hystrix</groupId>
+            <artifactId>hystrix-core</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>net.jodah</groupId>
+            <artifactId>failsafe</artifactId>
+            <optional>true</optional>
+        </dependency>
+
         <!-- TESTING -->
         <dependency>
             <groupId>org.zalando.stups</groupId>

--- a/stups-spring-oauth2-server/src/main/java/org/zalando/stups/oauth2/spring/server/FailsafeTokenInfoRequestExecutor.java
+++ b/stups-spring-oauth2-server/src/main/java/org/zalando/stups/oauth2/spring/server/FailsafeTokenInfoRequestExecutor.java
@@ -1,0 +1,55 @@
+package org.zalando.stups.oauth2.spring.server;
+
+import net.jodah.failsafe.CircuitBreaker;
+import net.jodah.failsafe.Failsafe;
+import net.jodah.failsafe.RetryPolicy;
+import org.springframework.util.Assert;
+import org.springframework.web.client.RestOperations;
+
+import java.util.Map;
+import java.util.concurrent.Callable;
+
+public class FailsafeTokenInfoRequestExecutor extends DefaultTokenInfoRequestExecutor {
+
+  private static Map<String, Object> FALLBACK = null;
+
+  private final CircuitBreaker circuitBreaker;
+
+  private final RetryPolicy retryPolicy;
+
+  public FailsafeTokenInfoRequestExecutor(
+      final String tokenInfoEndpointUrl,
+      final CircuitBreaker circuitBreaker,
+      final RetryPolicy retryPolicy) {
+    this(tokenInfoEndpointUrl, buildRestTemplate(), circuitBreaker, retryPolicy);
+  }
+
+  public FailsafeTokenInfoRequestExecutor(
+      final String tokenInfoEndpointUrl,
+      final RestOperations restOperations,
+      final CircuitBreaker circuitBreaker,
+      final RetryPolicy retryPolicy) {
+    super(tokenInfoEndpointUrl, restOperations);
+
+    Assert.notNull(circuitBreaker, "'circuitBreaker' should never be null");
+    Assert.notNull(retryPolicy, "'retryPolicy' should never be null");
+
+    this.circuitBreaker = circuitBreaker;
+    this.retryPolicy = retryPolicy;
+  }
+
+  @Override
+  public Map<String, Object> getMap(final String accessToken) {
+    Callable<Map<String, Object>> callable = new Callable<Map<String, Object>>() {
+      @Override
+      public Map<String, Object> call() throws Exception {
+        return FailsafeTokenInfoRequestExecutor.super.getMap(accessToken);
+      }
+    };
+    return Failsafe
+        .with(retryPolicy)
+        .with(circuitBreaker)
+        .withFallback(FALLBACK)
+        .get(callable);
+  }
+}

--- a/stups-spring-oauth2-server/src/main/java/org/zalando/stups/oauth2/spring/server/HystrixTokenInfoRequestExecutor.java
+++ b/stups-spring-oauth2-server/src/main/java/org/zalando/stups/oauth2/spring/server/HystrixTokenInfoRequestExecutor.java
@@ -1,0 +1,50 @@
+package org.zalando.stups.oauth2.spring.server;
+
+import com.netflix.hystrix.HystrixCommand;
+import com.netflix.hystrix.HystrixCommandGroupKey;
+import org.springframework.web.client.RestOperations;
+
+import java.util.Map;
+
+public class HystrixTokenInfoRequestExecutor extends DefaultTokenInfoRequestExecutor {
+
+  public HystrixTokenInfoRequestExecutor(String tokenInfoEndpointUrl) {
+    super(tokenInfoEndpointUrl);
+  }
+
+  public HystrixTokenInfoRequestExecutor(
+      final String tokenInfoEndpointUrl,
+      final RestOperations restOperations) {
+    super(tokenInfoEndpointUrl, restOperations);
+  }
+
+  @Override
+  public final Map<String, Object> getMap(final String accessToken) {
+    return new TokenInfoCommand(this, accessToken).execute();
+  }
+
+  static class TokenInfoCommand extends HystrixCommand<Map<String, Object>> {
+
+    private final HystrixTokenInfoRequestExecutor tokenInfoRequestExecutor;
+
+    private final String accessToken;
+
+    TokenInfoCommand(
+        final HystrixTokenInfoRequestExecutor tokenInfoRequestExecutor,
+        final String accessToken) {
+      super(HystrixCommandGroupKey.Factory.asKey("TokenInfo"));
+      this.tokenInfoRequestExecutor = tokenInfoRequestExecutor;
+      this.accessToken = accessToken;
+    }
+
+    @Override
+    protected Map<String, Object> run() throws Exception {
+      return tokenInfoRequestExecutor.doGetMap(accessToken);
+    }
+
+    @Override
+    protected Map<String, Object> getFallback() {
+      return null;
+    }
+  }
+}


### PR DESCRIPTION
This will address #53 and allow to have special TokenInfoRequestExecutor implementations which integrate with Hystrix and Failsafe.

This will not change any default behaviour of the library so far. It is expected for any configuration code (either auto configuration or manual configuration) to pick the correct implementation. Both Hystrix as well as Failsafe are marked as `optional` dependencies in order to not increase the dependency graph.