### PR TITLE
Release latest code in master

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 	</parent>
 	<groupId>org.zalando.stups</groupId>
 	<artifactId>stups-spring-oauth2-support</artifactId>
-	<version>1.0.21</version>
+	<version>1.0.22-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<modules>
@@ -185,7 +185,7 @@
 		<connection>scm:git:git@github.com:zalando-stups/stups-spring-oauth2-support.git</connection>
 		<developerConnection>scm:git:git@github.com:zalando-stups/stups-spring-oauth2-support.git</developerConnection>
 		<url>https://github.com/zalando-stups/stups-spring-oauth2-support</url>
-		<tag>1.0.21</tag>
+		<tag>HEAD</tag>
 	</scm>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 	</parent>
 	<groupId>org.zalando.stups</groupId>
 	<artifactId>stups-spring-oauth2-support</artifactId>
-	<version>1.0.21-SNAPSHOT</version>
+	<version>1.0.21</version>
 	<packaging>pom</packaging>
 
 	<modules>
@@ -185,7 +185,7 @@
 		<connection>scm:git:git@github.com:zalando-stups/stups-spring-oauth2-support.git</connection>
 		<developerConnection>scm:git:git@github.com:zalando-stups/stups-spring-oauth2-support.git</developerConnection>
 		<url>https://github.com/zalando-stups/stups-spring-oauth2-support</url>
-		<tag>HEAD</tag>
+		<tag>1.0.21</tag>
 	</scm>
 
 </project>

--- a/stups-http-components-oauth2/pom.xml
+++ b/stups-http-components-oauth2/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>org.zalando.stups</groupId>
 		<artifactId>stups-spring-oauth2-support</artifactId>
-		<version>1.0.21</version>
+		<version>1.0.22-SNAPSHOT</version>
 	</parent>
 	<artifactId>stups-http-components-oauth2</artifactId>
 

--- a/stups-http-components-oauth2/pom.xml
+++ b/stups-http-components-oauth2/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>org.zalando.stups</groupId>
 		<artifactId>stups-spring-oauth2-support</artifactId>
-		<version>1.0.21-SNAPSHOT</version>
+		<version>1.0.21</version>
 	</parent>
 	<artifactId>stups-http-components-oauth2</artifactId>
 

--- a/stups-jaxws-oauth2/pom.xml
+++ b/stups-jaxws-oauth2/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>org.zalando.stups</groupId>
 		<artifactId>stups-spring-oauth2-support</artifactId>
-		<version>1.0.21</version>
+		<version>1.0.22-SNAPSHOT</version>
 	</parent>
 	<artifactId>stups-jaxws-oauth2</artifactId>
 

--- a/stups-jaxws-oauth2/pom.xml
+++ b/stups-jaxws-oauth2/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>org.zalando.stups</groupId>
 		<artifactId>stups-spring-oauth2-support</artifactId>
-		<version>1.0.21-SNAPSHOT</version>
+		<version>1.0.21</version>
 	</parent>
 	<artifactId>stups-jaxws-oauth2</artifactId>
 

--- a/stups-spring-oauth2-client/pom.xml
+++ b/stups-spring-oauth2-client/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>org.zalando.stups</groupId>
 		<artifactId>stups-spring-oauth2-support</artifactId>
-		<version>1.0.21</version>
+		<version>1.0.22-SNAPSHOT</version>
 	</parent>
 	<artifactId>stups-spring-oauth2-client</artifactId>
 

--- a/stups-spring-oauth2-client/pom.xml
+++ b/stups-spring-oauth2-client/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>org.zalando.stups</groupId>
 		<artifactId>stups-spring-oauth2-support</artifactId>
-		<version>1.0.21-SNAPSHOT</version>
+		<version>1.0.21</version>
 	</parent>
 	<artifactId>stups-spring-oauth2-client</artifactId>
 

--- a/stups-spring-oauth2-common/pom.xml
+++ b/stups-spring-oauth2-common/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.zalando.stups</groupId>
         <artifactId>stups-spring-oauth2-support</artifactId>
-        <version>1.0.21-SNAPSHOT</version>
+        <version>1.0.21</version>
     </parent>
     <artifactId>stups-spring-oauth2-common</artifactId>
 

--- a/stups-spring-oauth2-common/pom.xml
+++ b/stups-spring-oauth2-common/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.zalando.stups</groupId>
         <artifactId>stups-spring-oauth2-support</artifactId>
-        <version>1.0.21</version>
+        <version>1.0.22-SNAPSHOT</version>
     </parent>
     <artifactId>stups-spring-oauth2-common</artifactId>
 

--- a/stups-spring-oauth2-server/pom.xml
+++ b/stups-spring-oauth2-server/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.zalando.stups</groupId>
         <artifactId>stups-spring-oauth2-support</artifactId>
-        <version>1.0.21-SNAPSHOT</version>
+        <version>1.0.21</version>
     </parent>
     <artifactId>stups-spring-oauth2-server</artifactId>
 

--- a/stups-spring-oauth2-server/pom.xml
+++ b/stups-spring-oauth2-server/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.zalando.stups</groupId>
         <artifactId>stups-spring-oauth2-support</artifactId>
-        <version>1.0.21</version>
+        <version>1.0.22-SNAPSHOT</version>
     </parent>
     <artifactId>stups-spring-oauth2-server</artifactId>
 


### PR DESCRIPTION
To get the changes made after 19 Jan 2018 e.g. [this one](https://github.com/zalando-stups/stups-spring-oauth2-support/pull/59).