### PR TITLE
Updated tokens library version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
 		<mockito.version>2.18.3</mockito.version>
 		<json-path.version>2.4.0</json-path.version>
 
-		<stups-tokens.version>0.11.0</stups-tokens.version>
+		<stups-tokens.version>0.12.1</stups-tokens.version>
 		<spring-boot-zalando-stups-tokens.version>0.9.11</spring-boot-zalando-stups-tokens.version>
 
 		<hystrix.version>1.5.12</hystrix.version>


### PR DESCRIPTION
Tokens 0.12.x is more k8s friendly and does not require CREDENTIALS_DIR environment variable to be declared. 
Took a while to figure out why my app was complaining in k8s after migration. 